### PR TITLE
Adding JUnit dependency

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ repositories {
 }
 
 dependencies {
+    testCompile 'junit:junit:4.12'
     compile gradleApi()
     compile localGroovy()
     testCompile gradleTestKit()


### PR DESCRIPTION
Fix for #1 Compile error Caused by: java.lang.ClassNotFoundException: junit.framework.TestCase